### PR TITLE
INTEG-139: Disable Social listeners for KS when profile social isn't activated

### DIFF
--- a/integ-ks/integ-ks-social/src/main/resources/conf/portal/configuration.xml
+++ b/integ-ks/integ-ks-social/src/main/resources/conf/portal/configuration.xml
@@ -4,7 +4,7 @@
  <!-- Social integration -->
    <external-component-plugins>
     <target-component>org.exoplatform.social.core.space.spi.SpaceService</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>ForumDataInitialize</name>
       <set-method>addSpaceListener</set-method>
       <type>org.exoplatform.ks.ext.impl.ForumDataInitialize</type>
@@ -15,7 +15,7 @@
 				</value-param>
 			</init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>AnswerDataInitialize</name>
       <set-method>addSpaceListener</set-method>
       <type>org.exoplatform.ks.ext.impl.AnswerDataInitialize</type>
@@ -30,7 +30,7 @@
 	
 	<external-component-plugins>
     <target-component>org.exoplatform.wiki.service.WikiService</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>Wiki listener for Social Space</name>
       <set-method>addComponentPlugin</set-method>
       <type>org.exoplatform.ks.ext.impl.WikiSpaceActivityPublisher</type>
@@ -45,7 +45,7 @@
 	
    <external-component-plugins>
     <target-component>org.exoplatform.forum.service.ForumService</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>ForumEventListener</name>
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.ks.ext.impl.ForumSpaceActivityPublisher</type>
@@ -54,7 +54,7 @@
   
   <external-component-plugins>
     <target-component>org.exoplatform.faq.service.FAQService</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>AnswerEventListener</name>
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.ks.ext.impl.AnswersSpaceActivityPublisher</type>
@@ -63,7 +63,7 @@
 
   <external-component-plugins>
     <target-component>org.exoplatform.social.core.space.spi.SpaceService</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>portlets.prefs.required</name>
       <set-method>setPortletsPrefsRequired</set-method>
       <type>org.exoplatform.social.core.application.PortletPreferenceRequiredPlugin</type>
@@ -82,7 +82,7 @@
 	<!-- configure activies plugin -->
 	<external-component-plugins>
     <target-component>org.exoplatform.webui.ext.UIExtensionManager</target-component>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>add.ks.forum.activity.plugin</name>
       <set-method>registerUIExtensionPlugin</set-method>
       <type>org.exoplatform.webui.ext.UIExtensionPlugin</type>
@@ -98,7 +98,7 @@
         </object-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>add.ks.answer.activity.plugin</name>
       <set-method>registerUIExtensionPlugin</set-method>
       <type>org.exoplatform.webui.ext.UIExtensionPlugin</type>
@@ -114,7 +114,7 @@
         </object-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="default,all,social">
       <name>add.ks.wiki.activity.plugin</name>
       <set-method>registerUIExtensionPlugin</set-method>
       <type>org.exoplatform.webui.ext.UIExtensionPlugin</type>
@@ -136,7 +136,7 @@
 	<external-component-plugins>
 		<!-- The full qualified name of the ResourceBundleService -->
 		<target-component>org.exoplatform.services.resources.ResourceBundleService</target-component>
-		<component-plugin>
+		<component-plugin profiles="default,all,social">
 			<!-- The name of the plugin -->
 			<name>KS-Social integration ResourceBundle Plugin</name>
 			<!-- The name of the method to call on the ResourceBundleService in order to register the ResourceBundles -->


### PR DESCRIPTION
Problem analysis:
- Starting the server without including the social profile, the related listeners for KS should not be called.

Fix description:
- Restrict the execution only for the profiles social , default and all.
