### PR TITLE
INTEG-245: First comment is lost for deployed document

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
@@ -281,7 +281,7 @@ public class Utils {
         }catch (Exception e){
           //Not activity is deleted, return no related activity
         }
-        if (exa!=null && !commentFlag) {
+        if (exa!=null && !commentFlag && isSystemComment) {
           activityManager.saveComment(exa, activity);
           if (node.isNodeType(MIX_COMMENT)) {
             commentID = activity.getId();
@@ -408,7 +408,7 @@ public class Utils {
         }catch (Exception e){
           //Not activity is deleted, return no related activity
         }
-        if (exa!=null && !commentFlag) {
+        if (exa!=null && !commentFlag && isSystemComment) {
           activityManager.saveComment(exa, activity);
           if (node.isNodeType(MIX_COMMENT)) {
             commentID = activity.getId();


### PR DESCRIPTION
Problem analysis:
- In the previous commit, if an activity is not created, we created and add a new comment. It's true for a deleted and restored document but not true for a new document

Fix description:
- Add a condition to add comment only for restored document
