### PR TITLE
INTEG-304 | [QuickSearch] Last characters are sometimes trancated from s...

### DIFF
--- a/integ-search-portlet/src/main/webapp/js/common/quicksearch.js
+++ b/integ-search-portlet/src/main/webapp/js/common/quicksearch.js
@@ -13,16 +13,15 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
     var seeAll_id = "#seeAll-" + portletId;
     var value = $(txtQuickSearchQuery_id).val();
     var isDefault = false;
-    var isEnterKey = false;
     window['isSearching'] = false;
-    var durationKeyup = 0;
-    var firstKeyup = 0;
-    var nextKeyup = 0;
-    var skipKeyup = 0;
     var textVal = "";
-    var firstBackSpace = true;
     var index = 0;
     var currentFocus = 0;
+    var searchTimeout;
+    var searchDelay = 1000;
+    var isLoading = false;
+    var types;
+    var searchPage = "/portal/"+eXo.env.portal.portalName+"/search";
     //var skipKeyUp = [9,16,17,18,19,20,33,34,35,36,37,38,39,40,45,49];
     
     var mapKeyUp = {"0":"48","1":"49","2":"50","3":"51","4":"52","5":"53","6":"54","7":"55","8":"56","9":"57",
@@ -188,10 +187,8 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
     	
     }
 
-    function quickSearch() {
-      var query = $(txtQuickSearchQuery_id).val();
-      setWaitingStatus(true);
-      var types = QUICKSEARCH_SETTING.searchTypes.join(","); //search for the types specified in quick search setting only
+    function quickSearch(query) {
+      types = QUICKSEARCH_SETTING.searchTypes.join(","); //search for the types specified in quick search setting only
 
       var searchParams = {
         searchContext: {
@@ -239,10 +236,10 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
         $(txtQuickSearchQuery_id).removeClass("loadding");
         setWaitingStatus(false);
         
-        var searchPage = "/portal/"+eXo.env.portal.portalName+"/search";
-        $(seeAll_id).attr("href", searchPage +"?q="+query+"&types="+types); //the query to be passed to main search page      
+        $(seeAll_id).attr("href", searchPage +"?q="+query+"&types="+types); //the query to be passed to main search page
         currentFocus = 0;
       });
+      isLoading = false;
     }
 
 
@@ -306,47 +303,51 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
 
     //*** Event handlers - Quick search ***
     $(document).on("click",seeAll_id, function(){
-      window.location.href = $(this).attr("href"); //open the main search page
+      var currentTextQueryHref = searchPage + "?q=" + $(txtQuickSearchQuery_id).val() + "&types=" + types;
+      //Ensure always that correct search query from $(txtQuickSearchQuery_id) is used
+      window.location.href = ($(this).attr("href") === currentTextQueryHref) ? $(this).attr("href") : currentTextQueryHref; //open the main search page
       $(quickSearchResult_id).hide();
     });
 
+    function reloadSearch(query, event){
+        if (!charDeletedIsEmpty(event, textVal, query)) {
+            //No search is performed unless: No other search is performed
+            if (!isLoading) {
+                setWaitingStatus(true);
+                $.each(mapKeyUp, function (key, value) {
+                    if ((value == event.keyCode)) {
+                        //Call search action within a timeout delay to ensure whole wold is searched when user stops typing
+                        searchTimeout = setTimeout(function () {
+                            isLoading = true;
+                            quickSearch(query); //search for the text just being typed in
+                        }, searchDelay);
+                    }
+                });
+            }
+        } else { //Should remove the waiting status when we delete a word with 1 or 0 characters
+            setWaitingStatus(false);
+        }
+    }
+
 
     $(txtQuickSearchQuery_id).keyup(function(e){
-      if(""==$(this).val()) {
-        $(quickSearchResult_id).hide();
-        return;
-      }
-      if(13==e.keyCode) {
-        $(seeAll_id).click(); //go to main search page if Enter is pressed
-      } else {
-          //quickSearch(); //search for the text just being typed in
-		  var currentVal = $(txtQuickSearchQuery_id).val();    	  
-    	  if (!charDeletedIsEmpty(e,textVal, currentVal)){
-    		  $.each(mapKeyUp, function(key, value){
-        		  
-    	    	  if (value == e.keyCode){
-    	    		var query = $(txtQuickSearchQuery_id).val();
-    	    		nextKeyup = new Date().getTime();	    
-    	    		
-    		    	if (query.length <= 2)
-    		      	{
-    		    		quickSearch(); //search for the text just being typed in
-    		      	}else if (nextKeyup - firstKeyup >= 1000){
-    			    		firstKeyup = nextKeyup;	    		
-    			    		quickSearch(); //search for the text just being typed in	    		
-    			    }else skipKeyup ++;
-    		    	
-    	 		    if (skipKeyup == 2)
-    			    {
-    				   skipKeyup = 0;
-    				   quickSearch();
-    				   firstKeyup = nextKeyup;
-    				}
-    	    	  }
-    	    	  textVal = $(txtQuickSearchQuery_id).val();
-        	  });
-    	  }    	      	      	 
-      }
+        var queryText = $(this).val();
+        if (13 == e.keyCode) {
+            e.preventDefault();
+            //Clear the timeout since this action should be done immediately
+            if (searchTimeout) {
+                clearTimeout(searchTimeout);
+            }
+            $(seeAll_id).trigger("click");//go to main search page if Enter is pressed
+        } else if ("" == queryText) {
+            $(quickSearchResult_id).hide();
+        } else {
+            if (searchTimeout) {
+                //Clear the timeout if is has been set by another search operation
+                clearTimeout(searchTimeout);
+            }
+            reloadSearch(queryText, e);
+        }
     });
     
     //skip backspace and delete key
@@ -358,7 +359,8 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
     	//process delete key
     	if (key.keyCode == 46 && textVal.trim() == currentVal.trim()){
 			return true;
-    	}    	
+    	}
+        return false;
     }
     // catch ennter key when search is running
     $(document).keyup(function (e) {
@@ -443,7 +445,7 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
     	  }else if (window['isSearching']){    	  	 
           
 	          var query = $(txtQuickSearchQuery_id).val();
-	          var types = QUICKSEARCH_SETTING.searchTypes.join(","); //search for the types specified in quick search setting only
+	          types = QUICKSEARCH_SETTING.searchTypes.join(","); //search for the types specified in quick search setting only
 	
 	          var searchParams = {
 	            searchContext: {
@@ -456,8 +458,8 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
 	            limit: QUICKSEARCH_SETTING.resultsPerPage,
 	            sort: "relevancy",
 	            order: "desc"
-	          };          
-	          var searchPage = "/portal/"+eXo.env.portal.portalName+"/search";
+	          };
+
 	          $(linkQuickSearchQuery_id).attr("onclick","window.location.href='"+searchPage +"?q="+query+"&types="+types+"'");
 	          window['isSearching'] = false;
     	  }


### PR DESCRIPTION
...earch query
**Problem analysis:**
- Sometimes words in quicksearch input are trancated and not the full word is used. This is caused by delay verification logic between _keyup_ events: 

``` javascript
if (query.length <= 2)
{
  quickSearch(); //search for the text just being typed in
} else if (nextKeyup - firstKeyup >= 1000){
  firstKeyup = nextKeyup;   
  quickSearch(); //search for the text just being typed in
} else skipKeyup ++;
  if (skipKeyup == 2)
  {
    skipKeyup = 0;
    quickSearch();
    firstKeyup = nextKeyup;
  }
}
```

**Fix Description:**
- Execute the search function within a timeout delay to avoid searching as user enters new keys though ensure whole world is searched.

``` javascript
searchTimeout = setTimeout(function() {
                  isLoading = true;
                  quickSearch(query); //search for the text just being typed in
                }, delay);
```
