### PR TITLE
INTEG-403: [Unified Search] Customized Search Result Settings aren't …

### DIFF
--- a/integ-search-portlet/pom.xml
+++ b/integ-search-portlet/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>portlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-api</artifactId>
+    </dependency>
     <!-- We want to be sure to use the right version in the dependency plugin but it's not required in the package -->
     <dependency>
       <groupId>org.exoplatform.platform-ui</groupId>

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/QuickSearch.java
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/QuickSearch.java
@@ -30,9 +30,15 @@ import juzu.template.Template;
 import javax.inject.Inject;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletPreferences;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
 
 /**
  * Created by The eXo Platform SAS
@@ -54,28 +60,36 @@ public class QuickSearch {
   PortletPreferences portletPreferences;  
   
   @Inject
+  SettingService settingService;
+
+  @Inject
   ResourceBundle bundle;  
 
-  static boolean firstInit = true;
   
   @View
   public Response.Content index(RequestContext requestContext){
     Map<String, Object> parameters = new HashMap<String, Object>();
     QuickSearch_.index().setProperty(JuzuPortlet.PORTLET_MODE, PortletMode.EDIT);
     PortletMode mode = requestContext.getProperty(JuzuPortlet.PORTLET_MODE);
-    parameters.put("firstInit", firstInit);
-    if (firstInit) firstInit = false;
+    SettingValue<?> resultsPerPageSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "resultsPerPage");
+    if (resultsPerPageSettingValue == null) {
+      String resultsPerPage = portletPreferences.getValue("resultsPerPage", "10");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "resultsPerPage", new SettingValue<Long>(Long.parseLong(resultsPerPage)));
+    }
+    SettingValue<?> searchTypesSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchTypes");
+    if (searchTypesSettingValue == null) {
+      String searchTypes = portletPreferences.getValue("searchTypes", "all");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchTypes", new SettingValue<String>(searchTypes));
+    }
+
+    SettingValue<?> searchCurrentSiteOnlySettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchCurrentSiteOnly");
+    if (searchCurrentSiteOnlySettingValue == null) {
+      String searchCurrentSiteOnly = portletPreferences.getValue("searchCurrentSiteOnly", "false");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchCurrentSiteOnly", new SettingValue<Boolean>(Boolean.parseBoolean(searchCurrentSiteOnly)));
+    }
     if (PortletMode.EDIT == mode){
       return edit.ok(parameters);
     }else {
-
-      String resultsPerPage = portletPreferences.getValue("resultsPerPage", "5");
-      String searchTypes = portletPreferences.getValue("searchTypes", "all");
-      String searchCurrentSiteOnly = portletPreferences.getValue("searchCurrentSiteOnly", "true");
-      
-      parameters.put("resultsPerPage", resultsPerPage);
-      parameters.put("searchTypes", searchTypes);
-      parameters.put("searchCurrentSiteOnly", searchCurrentSiteOnly);      
       return index.ok(parameters);
     }
   }  

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/package-info.java
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/package-info.java
@@ -17,7 +17,13 @@
 
 @Application
 @Portlet
+@Bindings({@Binding(SettingService.class)})
+
 package org.exoplatform.commons.quicksearch;
 
+import org.exoplatform.commons.api.settings.SettingService;
+
 import juzu.Application;
+import juzu.plugin.binding.Binding;
+import juzu.plugin.binding.Bindings;
 import juzu.plugin.portlet.Portlet;

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/templates/index.gtmpl
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/quicksearch/templates/index.gtmpl
@@ -18,6 +18,6 @@
 
 	<script>
 	  window.require(["PORTLET/unified-search/QuicksearchPortlet"], function() {
-		initQuickSearch("${portletId}","&{quicksearch.seeAll.label}","&{quicksearch.noResults.label}","&{quicksearch.searching.label}",${resultsPerPage},"${searchTypes}",${searchCurrentSiteOnly},${firstInit});
+		initQuickSearch("${portletId}","&{quicksearch.seeAll.label}","&{quicksearch.noResults.label}","&{quicksearch.searching.label}");
 	  });
 	</script>

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/Search.java
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/Search.java
@@ -30,6 +30,12 @@ import juzu.template.Template;
 import javax.inject.Inject;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletPreferences;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -54,34 +60,49 @@ public class Search {
   PortletPreferences portletPreferences;
   
   @Inject
+  SettingService settingService;
+
+  @Inject
   ResourceBundle bundle;    
 
-  static boolean firstInit = true;
-  
   @View
   public Response.Content index(RequestContext requestContext){
     Map<String, Object> parameters = new HashMap<String, Object>();        
     
     Search_.index().setProperty(JuzuPortlet.PORTLET_MODE, PortletMode.EDIT);
     PortletMode mode = requestContext.getProperty(JuzuPortlet.PORTLET_MODE);
-    parameters.put("firstInit", firstInit);
-    if (firstInit) firstInit = false;
+    
+    SettingValue<?> resultsPerPageSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_resultsPerPage");
+    if (resultsPerPageSettingValue == null) {
+      String resultsPerPage = portletPreferences.getValue("resultsPerPage", "10");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_resultsPerPage", new SettingValue<Long>(Long.parseLong(resultsPerPage)));
+    }
+    SettingValue<?> searchTypesSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchTypes");
+    if (searchTypesSettingValue == null) {
+      String searchTypes = portletPreferences.getValue("searchTypes", "all");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchTypes", new SettingValue<String>(searchTypes));
+    }
+
+    SettingValue<?> searchCurrentSiteOnlySettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchCurrentSiteOnly");
+    if (searchCurrentSiteOnlySettingValue == null) {
+      String searchCurrentSiteOnly = portletPreferences.getValue("searchCurrentSiteOnly", "false");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchCurrentSiteOnly", new SettingValue<Boolean>(Boolean.parseBoolean(searchCurrentSiteOnly)));
+    }
+
+    SettingValue<?> hideSearchFormSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideSearchForm");
+    if (hideSearchFormSettingValue == null) {
+      String hideSearchForm = portletPreferences.getValue("hideSearchForm", "false");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideSearchForm", new SettingValue<Boolean>(Boolean.parseBoolean(hideSearchForm)));
+    }
+
+    SettingValue<?> hideFacetsFilterSettingValue = settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideFacetsFilter");
+    if (hideFacetsFilterSettingValue == null) {
+      String hideFacetsFilter = portletPreferences.getValue("hideFacetsFilter", "false");
+      settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideFacetsFilter", new SettingValue<Boolean>(Boolean.parseBoolean(hideFacetsFilter)));
+    }
     if (PortletMode.EDIT == mode){
       return edit.ok(parameters);
     } else {
-      
-      String resultsPerPage = portletPreferences.getValue("resultsPerPage", "10");
-      String searchTypes = portletPreferences.getValue("searchTypes", "all");
-      String searchCurrentSiteOnly = portletPreferences.getValue("searchCurrentSiteOnly", "false");
-      String hideSearchForm = portletPreferences.getValue("hideSearchForm", "false");
-      String hideFacetsFilter = portletPreferences.getValue("hideFacetsFilter", "false");    
-      
-      parameters.put("resultsPerPage", resultsPerPage);
-      parameters.put("searchTypes", searchTypes);
-      parameters.put("searchCurrentSiteOnly", searchCurrentSiteOnly);
-      parameters.put("hideSearchForm", hideSearchForm);
-      parameters.put("hideFacetsFilter", hideFacetsFilter);
-      
       return index.ok(parameters);
     }
   }  

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/package-info.java
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/package-info.java
@@ -17,7 +17,12 @@
 
 @Application
 @Portlet
+@Bindings({@Binding(SettingService.class)})
 package org.exoplatform.commons.unifiedsearch;
 
 import juzu.Application;
+import juzu.plugin.binding.Binding;
+import juzu.plugin.binding.Bindings;
 import juzu.plugin.portlet.Portlet;
+
+import org.exoplatform.commons.api.settings.SettingService;

--- a/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/templates/index.gtmpl
+++ b/integ-search-portlet/src/main/java/org/exoplatform/commons/unifiedsearch/templates/index.gtmpl
@@ -64,6 +64,6 @@
 
 <script>
 window.require(["PORTLET/unified-search/UnifiedsearchPortlet"], function() {
-  initSearch(${resultsPerPage},'${searchTypes}',${searchCurrentSiteOnly},${hideSearchForm},${hideFacetsFilter},${firstInit}); 
+  initSearch();
 });  
 </script>

--- a/integ-search-portlet/src/main/webapp/js/common/quicksearch.js
+++ b/integ-search-portlet/src/main/webapp/js/common/quicksearch.js
@@ -1,6 +1,6 @@
 (function($){
 // Function to be called when the quick search template is ready
-window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultMsg, searching, resultsPerPage, searchTypes, searchCurrentSiteOnly,firstInit) {
+window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultMsg, searching) {
   
     //*** Global variables ***
     var CONNECTORS; //all registered SearchService connectors
@@ -135,21 +135,6 @@ window.initQuickSearch = function initQuickSearch(portletId,seeAllMsg, noResultM
       }
     }
     
-    $("document").ready(function(){
-      if (Boolean(firstInit)) {
-        var data = {};
-        if (typeof resultsPerPage != 'undefined') {
-          data["resultsPerPage"] = resultsPerPage;
-        }
-        if (typeof searchTypes != 'undefined') {
-          data["searchTypes"] = searchTypes;
-        }
-        if (typeof searchCurrentSiteOnly != 'undefined') {
-          data["searchCurrentSiteOnly"] = searchCurrentSiteOnly;
-        }
-        $.post("/rest/search/setting/quicksearch", data);
-      }
-    });         
     //*** Utility functions ***
     
     String.prototype.toProperCase = function() {

--- a/integ-search-portlet/src/main/webapp/js/common/search.js
+++ b/integ-search-portlet/src/main/webapp/js/common/search.js
@@ -1,6 +1,6 @@
 (function($){
   
-window.initSearch = function initSearch(resultsPerPage,searchTypes,searchCurrentSiteOnly,hideSearchForm,hideFacetsFilter,firstInit) {
+window.initSearch = function initSearch() {
 
     //*** Global variables ***
     var CONNECTORS; //all registered SearchService connectors
@@ -55,27 +55,6 @@ window.initSearch = function initSearch(resultsPerPage,searchTypes,searchCurrent
       </div> \
     ";    
       
-    $("document").ready(function(){
-      if (Boolean(firstInit)) {
-        var data = {};
-        if (typeof resultsPerPage != 'undefined') {
-          data["resultsPerPage"] = resultsPerPage;
-        }
-        if (typeof searchTypes != 'undefined') {
-          data["searchTypes"] = searchTypes;
-        }
-        if (typeof searchCurrentSiteOnly != 'undefined') {
-          data["searchCurrentSiteOnly"] = searchCurrentSiteOnly;
-        }
-        if (typeof hideSearchForm != 'undefined') {
-          data["hideSearchForm"] = hideSearchForm;
-        }
-        if (typeof hideFacetsFilter != 'undefined') {
-          data["hideFacetsFilter"] = hideFacetsFilter;
-        }
-        $.post("/rest/search/setting", data);
-      }
-    });  
     
     //*** Utility functions ***
     String.prototype.toProperCase = function() {

--- a/integ-search-service/src/main/java/org/exoplatform/commons/search/service/UnifiedSearchService.java
+++ b/integ-search-service/src/main/java/org/exoplatform/commons/search/service/UnifiedSearchService.java
@@ -221,17 +221,38 @@ public class UnifiedSearchService implements ResourceContainer {
     
   @SuppressWarnings("unchecked")
   private SearchSetting getSearchSetting() {
+    SearchSetting newSearchSetting = defaultSearchSetting;
     try {
-      Long resultsPerPage = ((SettingValue<Long>)settingService.get(Context.USER, Scope.WINDOWS, "resultsPerPage")).getValue();
-      String searchTypes = ((SettingValue<String>) settingService.get(Context.USER, Scope.WINDOWS, "searchTypes")).getValue();      
-      Boolean searchCurrentSiteOnly = ((SettingValue<Boolean>) settingService.get(Context.USER, Scope.WINDOWS, "searchCurrentSiteOnly")).getValue();
-      Boolean hideSearchForm = ((SettingValue<Boolean>) settingService.get(Context.USER, Scope.WINDOWS, "hideSearchForm")).getValue();
-      Boolean hideFacetsFilter = ((SettingValue<Boolean>) settingService.get(Context.USER, Scope.WINDOWS, "hideFacetsFilter")).getValue();
-      
-      return new SearchSetting(resultsPerPage, Arrays.asList(searchTypes.split(",\\s*")), searchCurrentSiteOnly, hideSearchForm, hideFacetsFilter);
-    } catch (Exception e) {
-      return defaultSearchSetting;
+      Long resultsPerPage = ((SettingValue<Long>)settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_resultsPerPage")).getValue();
+      newSearchSetting.setResultsPerPage(resultsPerPage);
+    } catch(Exception e) {
+      LOG.info("Cannot get searchResult_resultsPerPage parameter for search settings. Use default one instead");
     }
+    try {
+      String searchTypes = ((SettingValue<String>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchTypes")).getValue();
+      newSearchSetting.setSearchTypes(Arrays.asList(searchTypes.split(",\\s*")));
+    } catch (Exception e) {
+      LOG.info("Cannot get searchResult_searchTypes parameter for search settings. Use default one instead");
+    }
+    try {
+      Boolean searchCurrentSiteOnly = ((SettingValue<Boolean>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchCurrentSiteOnly")).getValue();
+      newSearchSetting.setSearchCurrentSiteOnly(searchCurrentSiteOnly);
+    } catch (Exception e) {
+      LOG.info("Cannot get searchResult_searchCurrentSiteOnly parameter for search settings. Use default one instead");
+    }
+    try {
+      Boolean hideSearchForm = ((SettingValue<Boolean>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideSearchForm")).getValue();
+      newSearchSetting.setHideSearchForm(hideSearchForm);
+    } catch (Exception e) {
+      LOG.info("Cannot get searchResult_hideSearchForm parameter for search settings. Use default one instead");
+    }
+    try {
+      Boolean hideFacetsFilter = ((SettingValue<Boolean>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideFacetsFilter")).getValue();
+      newSearchSetting.setHideFacetsFilter(hideFacetsFilter);
+    } catch (Exception e) {
+      LOG.info("Cannot get searchResult_hideFacetsFilter parameter for search settings. Use default one instead");
+    }
+    return newSearchSetting;
   }
 
   /**
@@ -258,11 +279,11 @@ public class UnifiedSearchService implements ResourceContainer {
   @POST
   @Path("/setting")
   public Response REST_setSearchSetting(@FormParam("resultsPerPage") long resultsPerPage, @FormParam("searchTypes") String searchTypes, @FormParam("searchCurrentSiteOnly") boolean searchCurrentSiteOnly, @FormParam("hideSearchForm") boolean hideSearchForm, @FormParam("hideFacetsFilter") boolean hideFacetsFilter) {
-    settingService.set(Context.USER, Scope.WINDOWS, "resultsPerPage", new SettingValue<Long>(resultsPerPage));    
-    settingService.set(Context.USER, Scope.WINDOWS, "searchTypes", new SettingValue<String>(searchTypes));
-    settingService.set(Context.USER, Scope.WINDOWS, "searchCurrentSiteOnly", new SettingValue<Boolean>(searchCurrentSiteOnly));
-    settingService.set(Context.USER, Scope.WINDOWS, "hideSearchForm", new SettingValue<Boolean>(hideSearchForm));
-    settingService.set(Context.USER, Scope.WINDOWS, "hideFacetsFilter", new SettingValue<Boolean>(hideFacetsFilter));
+    settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_resultsPerPage", new SettingValue<Long>(resultsPerPage));    
+    settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchTypes", new SettingValue<String>(searchTypes));
+    settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_searchCurrentSiteOnly", new SettingValue<Boolean>(searchCurrentSiteOnly));
+    settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideSearchForm", new SettingValue<Boolean>(hideSearchForm));
+    settingService.set(Context.GLOBAL, Scope.WINDOWS, "searchResult_hideFacetsFilter", new SettingValue<Boolean>(hideFacetsFilter));
     
     return Response.ok("ok", MediaType.APPLICATION_JSON).cacheControl(cacheControl).build();
   } 
@@ -270,15 +291,26 @@ public class UnifiedSearchService implements ResourceContainer {
 
   @SuppressWarnings("unchecked")
   private SearchSetting getQuickSearchSetting() {
+    SearchSetting newSearchSetting = defaultQuicksearchSetting;
     try {
       Long resultsPerPage = ((SettingValue<Long>)settingService.get(Context.GLOBAL, Scope.WINDOWS, "resultsPerPage")).getValue();
-      String searchTypes = ((SettingValue<String>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchTypes")).getValue();
-      Boolean searchCurrentSiteOnly = ((SettingValue<Boolean>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchCurrentSiteOnly")).getValue();
-      
-      return new SearchSetting(resultsPerPage, Arrays.asList(searchTypes.split(",\\s*")), searchCurrentSiteOnly, true, true);
-    } catch (Exception e) {
-      return defaultQuicksearchSetting;
+      newSearchSetting.setResultsPerPage(resultsPerPage);
+    } catch(Exception e) {
+      LOG.info("Cannot get resultsPerPage parameter for quick search settings. Use default one instead");
     }
+    try {
+      String searchTypes = ((SettingValue<String>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchTypes")).getValue();
+      newSearchSetting.setSearchTypes(Arrays.asList(searchTypes.split(",\\s*")));
+    } catch (Exception e) {
+      LOG.info("Cannot get searchTypes parameter for quick search settings. Use default one instead");
+    }
+    try {
+      Boolean searchCurrentSiteOnly = ((SettingValue<Boolean>) settingService.get(Context.GLOBAL, Scope.WINDOWS, "searchCurrentSiteOnly")).getValue();
+      newSearchSetting.setSearchCurrentSiteOnly(searchCurrentSiteOnly);
+    } catch (Exception e) {
+      LOG.info("Cannot get searchCurrentSiteOnly parameter for quick search settings. Use default one instead");
+    }
+    return newSearchSetting;
   }
 
   /**


### PR DESCRIPTION
…considered for all users

Fix description:
- Store flags which are used to check if search settings are initiated or not in SettingService.
- Scope of flags is the same with one of search settings
- Search result settings are global

Conflicts:
    integ-search-portlet/src/main/webapp/js/common/quicksearch.js
