### PR TITLE
INTEG-488 :Preview of contents is not localized

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
@@ -89,12 +89,13 @@ public class ContentViewerRESTService implements ResourceContainer {
    * @anchor PDFViewerRESTService.getPDFFile
    */
   @GET
-  @Path("/{repoName}/{workspaceName}/{uuid}/")
+  @Path("/{repoName}/{workspaceName}/{uuid}/{lang}")
     public Response getContent(@Context HttpServletRequest request,
                                @Context HttpServletResponse response,
                              @PathParam("repoName") String repoName,
                              @PathParam("workspaceName") String workspaceName,
-                             @PathParam("uuid") String uuid) throws Exception {
+                             @PathParam("uuid") String uuid,
+                             @PathParam("lang") String language) throws Exception {
     String content = null;
     try {
       ManageableRepository repository = repositoryService.getCurrentRepository();
@@ -116,12 +117,13 @@ public class ContentViewerRESTService implements ResourceContainer {
 
       ControllerContext controllerContext = new ControllerContext(webAppController, webAppController.getRouter(), request, response, null);
       PortalApplication application = webAppController.getApplication(PortalApplication.PORTAL_APPLICATION_ID);
-      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", request.getLocale());
+      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", null);
       WebuiRequestContext.setCurrentInstance(requestContext);
       UIPortalApplication uiApplication = new UIPortalApplication();
       uiApplication.setCurrentSite(new UIPortal());
       requestContext.setUIApplication(uiApplication);
       requestContext.setWriter(writer);
+      requestContext.setLocale(new Locale(language));
 
       uiDocViewer.processRender(requestContext);
 

--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
@@ -116,7 +116,7 @@ public class ContentViewerRESTService implements ResourceContainer {
 
       ControllerContext controllerContext = new ControllerContext(webAppController, webAppController.getRouter(), request, response, null);
       PortalApplication application = webAppController.getApplication(PortalApplication.PORTAL_APPLICATION_ID);
-      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", null);
+      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", request.getLocale());
       WebuiRequestContext.setCurrentInstance(requestContext);
       UIPortalApplication uiApplication = new UIPortalApplication();
       uiApplication.setCurrentSite(new UIPortal());

--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
@@ -52,8 +52,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Locale;
@@ -89,14 +91,15 @@ public class ContentViewerRESTService implements ResourceContainer {
    * @anchor PDFViewerRESTService.getPDFFile
    */
   @GET
-  @Path("/{repoName}/{workspaceName}/{uuid}/{lang}")
+  @Path("/{repoName}/{workspaceName}/{uuid}")
     public Response getContent(@Context HttpServletRequest request,
                                @Context HttpServletResponse response,
                              @PathParam("repoName") String repoName,
                              @PathParam("workspaceName") String workspaceName,
                              @PathParam("uuid") String uuid,
-                             @PathParam("lang") String language) throws Exception {
+                             @QueryParam("lang") String language) throws Exception {
     String content = null;
+    Locale local = language==null ? Locale.ENGLISH: new Locale(language);
     try {
       ManageableRepository repository = repositoryService.getCurrentRepository();
       Session session = getSystemProvider().getSession(workspaceName, repository);
@@ -123,7 +126,7 @@ public class ContentViewerRESTService implements ResourceContainer {
       uiApplication.setCurrentSite(new UIPortal());
       requestContext.setUIApplication(uiApplication);
       requestContext.setWriter(writer);
-      requestContext.setLocale(new Locale(language));
+      requestContext.setLocale(local);
 
       uiDocViewer.processRender(requestContext);
 


### PR DESCRIPTION
The main issue that we are using rest service to render the content preview, so we are manually creating 
webui context by setting the writer and the instance with the default Locale.
It's impossible to get the current local from the rest context.
Furthermore only portal resources bundle will be available at this level, from the reported issue we are trying to use portlet resource bundle "Category.view.label " so for me it's should be normal behavior to get this issue.
As we are using the same template that will be rendered in both file explorer context and the activity context (from the rest service)  to get around that and avoid  perf issue by loading all the  template resources bundle,  in the customer extension we can create these bundles at portal level 
 