### PR TITLE
MOB-2197 : determine mimetype of downloaded file from its properties …

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/activity/ActivityFilesDownloadResource.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/activity/ActivityFilesDownloadResource.java
@@ -43,7 +43,7 @@ public class ActivityFilesDownloadResource extends DownloadResource {
   private NodeLocation[] nodeLocations;
 
   public ActivityFilesDownloadResource(NodeLocation[] nodelocations) {
-    super("application/zip");
+    super(getMimetype(nodelocations));
     this.nodeLocations = nodelocations;
   }
 
@@ -106,4 +106,27 @@ public class ActivityFilesDownloadResource extends DownloadResource {
     }
   }
 
+  private static String getMimetype(NodeLocation[] nodeLocations) {
+    if (nodeLocations == null || nodeLocations.length == 0) {
+      return null;
+    }
+
+    if (nodeLocations.length == 1) {
+      NodeLocation nodeLocation = nodeLocations[0];
+      Node node = NodeLocation.getNodeByLocation(nodeLocation);
+      try {
+        if (node.isNodeType(NodetypeConstant.NT_FILE) && node.hasNode(NodetypeConstant.JCR_CONTENT)) {
+          Node contentNode = node.getNode(NodetypeConstant.JCR_CONTENT);
+          if (contentNode.hasProperty(NodetypeConstant.JCR_MIMETYPE)) {
+            return contentNode.getProperty(NodetypeConstant.JCR_MIMETYPE).getString();
+          }
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException("Error getting mimetype of file", e);
+      }
+      return "application/octet-stream";
+    } else {
+      return "application/zip";
+    }
+  }
 }


### PR DESCRIPTION
…(#264) (#196)

When downloading a file from an activity, the content-type is hardcoded to application/zip.
This causes the smartphone browser to consider the file as a zip and make it fail to display the fiie.

This fix determines the file mimetype from the its property jcr:mimeType, and keeps it to "application/zip" when multiple files are downloaded.