### PR TITLE
ECMS-8018:Activity images are lost when the file is renamed

### DIFF
--- a/integ-social/integ-social-ecms/src/main/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessor.java
+++ b/integ-social/integ-social-ecms/src/main/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessor.java
@@ -178,8 +178,11 @@ public class HTMLUploadImageProcessor {
   }
 
   private String getJcrURI(Node imageNode) throws RepositoryException {
-    return "/" + portalContainer.getName() + "/" + portalContainer.getRestContextName() + "/jcr/" + getRepositoryName() + "/"
-            + imageNode.getSession().getWorkspace().getName() + imageNode.getPath();
+    if(!imageNode.isNodeType(NodetypeConstant.MIX_REFERENCEABLE)) {
+      imageNode.addMixin(NodetypeConstant.MIX_REFERENCEABLE);
+    }
+    return "/" + portalContainer.getName() + "/" + portalContainer.getRestContextName() + "/images/" + getRepositoryName() + "/"
+        + imageNode.getSession().getWorkspace().getName() + "/" + imageNode.getUUID();
   }
 
   private static String getURLToReplace(String body, String uploadId, int uploadIdIndex) {

--- a/integ-social/integ-social-ecms/src/test/java/org/exoplatform/social/addons/rdbms/listener/ActivityImageLinkUpdateListenerTest.java
+++ b/integ-social/integ-social-ecms/src/test/java/org/exoplatform/social/addons/rdbms/listener/ActivityImageLinkUpdateListenerTest.java
@@ -110,68 +110,73 @@ public class ActivityImageLinkUpdateListenerTest extends BaseCommonsTestCase {
   }
 
   public void testShouldUpdateImagesLinksWhenImageEmbeddedInBody() throws Exception {
+    // Given
     String uploadId = String.valueOf((long) (Math.random() * 100000L));
     String body = "<img src=\"http://localhost:8080/test?uploadId=" + uploadId + "\" />";
 
+    // When
     ExoSocialActivity activity = createActivityWithEmbeddedImage(rootIdentity, body, uploadId, null);
 
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml" + "\" />", activity.getBody());
+    // Then
+    assertTrue(activity.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     activity = activityManager.getActivity(activity.getId());
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml" + "\" />", activity.getBody());
+    assertTrue(activity.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     assertEquals(0, uploadService.getUploadResources().size());
   }
 
   public void testShouldUpdateImagesLinksWhenImageEmbeddedWithoutDomainInBody() throws Exception {
+    // Given
     String uploadId = String.valueOf((long) (Math.random() * 100000L));
     String body = "<img src=\"/test?uploadId=" + uploadId + "\" />";
 
+    // Then
     ExoSocialActivity activity = createActivityWithEmbeddedImage(rootIdentity, body, uploadId, null);
 
-    assertEquals("<img src=\""+"/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-        + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml"+"\" />", activity.getBody());
+    // When
+    assertTrue(activity.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     activity = activityManager.getActivity(activity.getId());
-    assertEquals("<img src=\""+"/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-        + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName" + ".xml\" />", activity.getBody());
+    assertTrue(activity.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     assertEquals(0, uploadService.getUploadResources().size());
   }
 
   public void testShouldUpdateImagesLinksWhenImageEmbeddedWithoutDomainInBodyAndFilesWithSameName() throws Exception {
+    // Given
     String uploadId1 = String.valueOf((long) (Math.random() * 100000L));
     String body1 = "<img src=\"http://localhost:8080/test?uploadId=" + uploadId1 + "\" />";
-    ExoSocialActivity activity1 = createActivityWithEmbeddedImage(rootIdentity, body1, uploadId1, null);
 
     String uploadId2 = String.valueOf((long) (Math.random() * 100000L));
     String body2 = "<img src=\"http://localhost:8080/test?uploadId=" + uploadId2 + "\" />";
+
+    // When
+    ExoSocialActivity activity1 = createActivityWithEmbeddedImage(rootIdentity, body1, uploadId1, null);
     ExoSocialActivity activity2 = createActivityWithEmbeddedImage(rootIdentity, body2, uploadId2, null);
 
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml" + "\" />", activity1.getBody());
+    // Then
+    assertTrue(activity1.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     activity1 = activityManager.getActivity(activity1.getId());
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml" + "\" />", activity1.getBody());
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName" + "%281%29.xml\" />", activity2.getBody());
+    assertTrue(activity1.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
+    assertTrue(activity2.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     activity2 = activityManager.getActivity(activity2.getId());
-    assertEquals("<img src=\"" + "/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName" + "%281%29.xml\" />", activity2.getBody());
+    assertTrue(activity2.getBody().matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     assertEquals(0, uploadService.getUploadResources().size());
   }
 
   public void testShouldUpdateImagesLinksWhenImageEmbeddedInTemplateParam() throws Exception {
+    // Given
     String uploadId = String.valueOf((long) (Math.random() * 100000L));
     String body = "body";
     Map<String, String> templateParams = new HashMap<>();
     templateParams.put("comment", "<img src=\"http://localhost:8080/test?uploadId=" + uploadId + "\" />");
 
+    // When
     ExoSocialActivity activity = createActivityWithEmbeddedImage(rootIdentity, body, uploadId, templateParams);
 
-    assertEquals("<img src=\""+"/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml"+"\" />", activity.getTemplateParams().get("comment"));
+    // Then
+    assertTrue(activity.getTemplateParams().get("comment")
+                       .matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     activity = activityManager.getActivity(activity.getId());
-    assertEquals("<img src=\""+"/portal/rest/jcr/repository/portal-test/Users/r___/ro___/roo___/root/Public/Activity Stream Documents/Pictures/"
-            + YearMonth.now().getYear() + "/" + monthFormat.format(YearMonth.now().getMonthValue()) + "/fileName.xml"+"\" />", activity.getTemplateParams().get("comment"));
+    assertTrue(activity.getTemplateParams().get("comment")
+                       .matches("<img src=\"/portal/rest/images/repository/portal-test/[a-z0-9]+\" />"));
     assertEquals(0, uploadService.getUploadResources().size());
   }
 

--- a/integ-social/integ-social-ecms/src/test/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessorTest.java
+++ b/integ-social/integ-social-ecms/src/test/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessorTest.java
@@ -1,6 +1,7 @@
 package org.exoplatform.social.ckeditor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -95,6 +96,6 @@ public class HTMLUploadImageProcessorTest {
     String processedContent = imageProcessor.processImages(content, node, null);
 
     // Then
-    assertEquals("<p>content with image: <img src=\"/portal/rest/jcr/repository/collaboration/path/to/image.png\" /></p>", processedContent);
+    assertTrue(processedContent.matches("<p>content with image: <img src=\"/portal/rest/images/repository/collaboration/[a-z0-9]+\" /></p>"));
   }
 }


### PR DESCRIPTION
Image URL used to insert images in activities used the image node path.
When image files are renamed, their path is changed, which breaks the URL and make the images disappear in the activities.

This fix uses another REST endpoint which refers to image by their unique and permanent id.